### PR TITLE
Retry 5 times if the page is not loaded (temporary fix)

### DIFF
--- a/tests/test_app_gallery.py
+++ b/tests/test_app_gallery.py
@@ -50,7 +50,19 @@ def get_gallery_app_page(app_name) -> Generator:
         """,
             [Config.id, Config.key, token],
         )
-        gallery_page.goto(f"{Config.url}/apps")
+
+        retry_count = 0
+        MAX_RETRY_COUNT = 5
+        while True:
+            try:
+                gallery_page.goto(f"{Config.url}/apps")
+            except playwright._impl._api_types.TimeoutError as e:
+                if retry_count >= MAX_RETRY_COUNT:
+                    raise e
+                retry_count += 1
+                continue
+            else:
+                break
 
         # Find the app in the gallery
         gallery_page.locator(f"text='{app_name}'").first.click()

--- a/tests/test_app_gallery.py
+++ b/tests/test_app_gallery.py
@@ -51,13 +51,14 @@ def get_gallery_app_page(app_name) -> Generator:
             [Config.id, Config.key, token],
         )
 
-        for retry_count in range(MAX_RETRY_COUNT):
+        for retry_count in range(5):
             try:
                 gallery_page.goto(f"{Config.url}/apps")
             except playwright._impl._api_types.TimeoutError as ex:
                 try_ex = ex
-            try_ex = None
-            break
+            else:
+                try_ex = None
+                break
         if try_ex:
             raise try_ex
 

--- a/tests/test_app_gallery.py
+++ b/tests/test_app_gallery.py
@@ -51,18 +51,15 @@ def get_gallery_app_page(app_name) -> Generator:
             [Config.id, Config.key, token],
         )
 
-        retry_count = 0
-        MAX_RETRY_COUNT = 5
-        while True:
+        for retry_count in range(MAX_RETRY_COUNT):
             try:
                 gallery_page.goto(f"{Config.url}/apps")
-            except playwright._impl._api_types.TimeoutError as e:
-                if retry_count >= MAX_RETRY_COUNT:
-                    raise e
-                retry_count += 1
-                continue
-            else:
-                break
+            except playwright._impl._api_types.TimeoutError as ex:
+                try_ex = ex
+            try_ex = None
+            break
+        if try_ex:
+            raise try_ex
 
         # Find the app in the gallery
         gallery_page.locator(f"text='{app_name}'").first.click()


### PR DESCRIPTION
## What does this PR do?

We have observed some flakyness on gallery e2e tests internally, with apps like InVideo, SpiderRan etc. Error message reads:

```python
playwright._impl._api_types.TimeoutError: Timeout 30000ms exceeded.
E       =========================== logs ===========================
E       navigating to "***/apps", waiting until "load"
E       ============================================================
```

The timeout of 30s exceeded for the link. Restarting the run though, fixes it. In this PR, I suggest a fix to retry loading the page if it times out (max_retry: 5 times)

### Does your PR introduce any breaking changes? If yes, please list them.

Nope!

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue or with the team? (not for typos and docs)
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally**?
- [ ] Did you **test your PR on cloud**?

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
